### PR TITLE
auto generated UpdatedAt and CreatedAt columns

### DIFF
--- a/FaceAnalyzer.Api/Data/AppDbContext.cs
+++ b/FaceAnalyzer.Api/Data/AppDbContext.cs
@@ -12,26 +12,9 @@ public class AppDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
-        {
-            var deletedAtProperty = entityType.FindProperty("DeletedAt");
-
-            if (deletedAtProperty != null)
-            {
-                // Create a lambda expression to filter out entities with DeletedAt set.
-                var parameter = Expression.Parameter(entityType.ClrType);
-                var deletedAtExpression = Expression.Lambda(
-                    Expression.Equal(
-                        Expression.Property(parameter, deletedAtProperty.PropertyInfo),
-                        Expression.Constant(null, deletedAtProperty.ClrType)
-                    ),
-                    parameter
-                );
-
-                // Set the filter for the entity type.
-                modelBuilder.Entity(entityType.ClrType).HasQueryFilter(deletedAtExpression);
-            }
-        }
+        modelBuilder.AddAutoUpdatedAt();
+        modelBuilder.AddAutoCreatedAt();
+        modelBuilder.AddDeletedAtQueryFilter();
     }
 
     public DbSet<User> Users { get; set; }

--- a/FaceAnalyzer.Api/Data/EFCoreExtensions.cs
+++ b/FaceAnalyzer.Api/Data/EFCoreExtensions.cs
@@ -1,0 +1,65 @@
+﻿using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace FaceAnalyzer.Api.Data;
+
+public static class EFCoreExtensions
+{
+    public static void AddDeletedAtQueryFilter(this ModelBuilder modelBuilder)
+    {
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            var deletedAtPropertyName = nameof(IDeletable.DeletedAt);
+            var deletedAtProperty = entityType.FindProperty(deletedAtPropertyName);
+
+            if (deletedAtProperty != null)
+            {
+                // (IDeletable entity) => entity.DeletedAt == null
+                var parameter = Expression.Parameter(entityType.ClrType);
+                var deletedAtExpression = Expression.Lambda(
+                    Expression.Equal(
+                        Expression.Property(parameter, deletedAtProperty.PropertyInfo),
+                        Expression.Constant(null, deletedAtProperty.ClrType)
+                    ),
+                    parameter
+                );
+
+                modelBuilder.Entity(entityType.ClrType)
+                    .HasQueryFilter(deletedAtExpression);
+            }
+        }
+    }
+
+    public static void AddAutoCreatedAt(this ModelBuilder modelBuilder)
+    {
+        const string createdAtPropertyName = nameof(EntityBase.CreatedAt);
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            var createdAt = entityType
+                        .FindProperty(createdAtPropertyName);
+            if (createdAt != null)
+            {
+                modelBuilder.Entity(entityType.ClrType)
+                    .Property(createdAtPropertyName)
+                    .HasColumnType("TIMESTAMP")
+                    .HasDefaultValueSql("CURRENT_TIMESTAMP");
+            }
+        }
+    }
+
+    public static void AddAutoUpdatedAt(this ModelBuilder modelBuilder)
+    {
+        const string updatedAtPropertyName = nameof(EntityBase.UpdatedAt);
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            var updatedAtProperty = entityType.FindProperty(updatedAtPropertyName);
+            if (updatedAtProperty != null)
+            {
+                modelBuilder.Entity(entityType.ClrType)
+                    .Property(updatedAtPropertyName)
+                    .HasColumnType("TIMESTAMP")
+                    .HasDefaultValueSql("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Applied  Auto Generated UpdateAt and Auto Genereated CreatedAt
By looping over all entities and add default sql values: 
The following default values are used specifically for this case according to [mysql documentation](https://dev.mysql.com/doc/refman/8.0/en/timestamp-initialization.html)

for auto updatedAt: DEFAULT **CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP**
and for auto createdAt:  DEFAULT **CURRENT_TIMESTAMP**
