### PR TITLE
Get reaction emotions filtered by emotion type.

### DIFF
--- a/FaceAnalyzer.Api/Business/Queries/GetReactionEmotionsQuery.cs
+++ b/FaceAnalyzer.Api/Business/Queries/GetReactionEmotionsQuery.cs
@@ -1,6 +1,7 @@
 using FaceAnalyzer.Api.Business.Contracts;
+using FaceAnalyzer.Api.Shared.Enum;
 using MediatR;
 
 namespace FaceAnalyzer.Api.Business.Queries;
 
-public record GetReactionEmotionsQuery(int ReactionId): IRequest<QueryResult<EmotionDto>>;
+public record GetReactionEmotionsQuery(int ReactionId, EmotionType? EmotionType): IRequest<QueryResult<EmotionDto>>;

--- a/FaceAnalyzer.Api/Business/UseCases/Reactions/GetReactionEmotionsUseCase.cs
+++ b/FaceAnalyzer.Api/Business/UseCases/Reactions/GetReactionEmotionsUseCase.cs
@@ -29,6 +29,7 @@ public class GetReactionEmotionsUseCase : BaseUseCase,
 
         var emotions = await DbContext.Emotions
             .Where(emotion => emotion.ReactionId == request.ReactionId)
+            .ConditionalWhere(request.EmotionType.HasValue, emotion => emotion.EmotionType == request.EmotionType)
             .ProjectTo<EmotionDto>(Mapper.ConfigurationProvider)
             .ToListAsync(cancellationToken);
         return emotions.ToQueryResult();

--- a/FaceAnalyzer.Api/Service/Controllers/ReactionController.cs
+++ b/FaceAnalyzer.Api/Service/Controllers/ReactionController.cs
@@ -4,6 +4,7 @@ using FaceAnalyzer.Api.Business.Commands.Reactions;
 using FaceAnalyzer.Api.Business.Contracts;
 using FaceAnalyzer.Api.Business.Queries;
 using FaceAnalyzer.Api.Data.Entities;
+using FaceAnalyzer.Api.Shared.Enum;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -32,9 +33,9 @@ public class ReactionController : ControllerBase
     }
 
     [HttpGet("{id}/emotions")]
-    public async Task<ActionResult<QueryResult<EmotionDto>>> GetReactionEmotions(int id)
+    public async Task<ActionResult<QueryResult<EmotionDto>>> GetReactionEmotions(int id, [FromQuery] EmotionType? type)
     {
-        var query = new GetReactionEmotionsQuery(id);
+        var query = new GetReactionEmotionsQuery(id, type);
         var result = await _mediator.Send(query);
         return Ok(result);
     }
@@ -42,7 +43,7 @@ public class ReactionController : ControllerBase
     [HttpGet("{id}/emotions/export")]
     public async Task<IActionResult> GetReactionEmotionsCsv(int id)
     {
-        var query = new GetReactionEmotionsQuery(id);
+        var query = new GetReactionEmotionsQuery(id, null);
         var result = await _mediator.Send(query);
         
         // Convert list to a csv file


### PR DESCRIPTION
- Used to display emotions distribution over time, Frontend should get a reaction emotions filtered by emotion type and then manipulate the returned list as needed for the chart displayment.