### PR TITLE
added endpoint to create both reaction and emotions together

### DIFF
--- a/FaceAnalyzer.Api/Business/Commands/Reactions/CreateReactionCommand.cs
+++ b/FaceAnalyzer.Api/Business/Commands/Reactions/CreateReactionCommand.cs
@@ -3,4 +3,8 @@ using MediatR;
 
 namespace FaceAnalyzer.Api.Business.Commands.Reactions;
 
-public record CreateReactionCommand(int StimuliId, string ParticipantName): IRequest<ReactionDto>;
+public record CreateReactionCommand(
+    int StimuliId,
+    string ParticipantName,
+    IList<EmotionReading> EmotionReadings
+    ): IRequest<ReactionDto>;

--- a/FaceAnalyzer.Api/Business/Contracts/EmotionReading.cs
+++ b/FaceAnalyzer.Api/Business/Contracts/EmotionReading.cs
@@ -1,0 +1,8 @@
+﻿using FaceAnalyzer.Api.Shared.Enum;
+
+namespace FaceAnalyzer.Api.Business.Contracts;
+
+public record EmotionReading(
+    long Time,
+    IDictionary<EmotionType, double> Values
+);

--- a/FaceAnalyzer.Api/Business/UseCases/Reactions/CreateReactionUseCase.cs
+++ b/FaceAnalyzer.Api/Business/UseCases/Reactions/CreateReactionUseCase.cs
@@ -18,7 +18,8 @@ public class CreateReactionUseCase : BaseUseCase, IRequestHandler<CreateReaction
 
     public async Task<ReactionDto> Handle(CreateReactionCommand request, CancellationToken cancellationToken)
     {
-        var stimuliExist = await DbContext.Stimuli.AnyAsync(stimuli => stimuli.Id == request.StimuliId);
+        var stimuliExist = await DbContext.Stimuli
+            .AnyAsync(stimuli => stimuli.Id == request.StimuliId, cancellationToken);
         if (!stimuliExist)
         {
             throw new InvalidArgumentsExceptionBuilder()
@@ -27,11 +28,30 @@ public class CreateReactionUseCase : BaseUseCase, IRequestHandler<CreateReaction
                 .Build();
         }
 
+
         var reaction = new Reaction
         {
             ParticipantName = request.ParticipantName,
             StimuliId = request.StimuliId,
         };
+
+        reaction.Emotions = request.EmotionReadings
+            .SelectMany(reading =>
+            {
+                var values = new List<Emotion>();
+                foreach (var kv in reading.Values)
+                {
+                    var emotion = new Emotion
+                    {
+                        EmotionType = kv.Key,
+                        Value = kv.Value,
+                        TimeOffset = reading.Time
+                    };
+                    values.Add(emotion);
+                }
+
+                return values;
+            }).ToList();
         DbContext.Add(reaction);
         await DbContext.SaveChangesAsync(cancellationToken);
         return Mapper.Map<ReactionDto>(reaction);

--- a/FaceAnalyzer.Api/FaceAnalyzer.Api.csproj
+++ b/FaceAnalyzer.Api/FaceAnalyzer.Api.csproj
@@ -23,7 +23,9 @@
         </PackageReference>
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3"/>
+        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.12" />
 
     </ItemGroup>
+
 
 </Project>

--- a/FaceAnalyzer.Api/Program.cs
+++ b/FaceAnalyzer.Api/Program.cs
@@ -3,7 +3,6 @@ using FaceAnalyzer.Api.Business;
 using FaceAnalyzer.Api.Service;
 using FaceAnalyzer.Api.Service.Middlewares;
 using FaceAnalyzer.Api.Shared;
-using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,7 +12,7 @@ builder.Services.AddControllers().AddJsonOptions(opt =>
 {
     opt.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
 });
-builder.Services.AddSwagger();
+builder.Services.ConfigureSwagger();
 var config = new AppConfiguration();
 
 builder.Configuration.Bind(config);

--- a/FaceAnalyzer.Api/Service/Contracts/CreateReactionDto.cs
+++ b/FaceAnalyzer.Api/Service/Contracts/CreateReactionDto.cs
@@ -1,5 +1,9 @@
-﻿using FaceAnalyzer.Api.Data.Entities;
+﻿using FaceAnalyzer.Api.Business.Contracts;
 
 namespace FaceAnalyzer.Api.Service.Contracts;
 
-public record CreateReactionDto( int StimuliId, string PartecipantName);
+
+public record CreateReactionDto(
+    int StimuliId,
+    string ParticipantName,
+    IList<EmotionReading> EmotionReadings);

--- a/FaceAnalyzer.Api/Service/Controllers/ReactionController.cs
+++ b/FaceAnalyzer.Api/Service/Controllers/ReactionController.cs
@@ -4,31 +4,47 @@ using FaceAnalyzer.Api.Business.Commands.Reactions;
 using FaceAnalyzer.Api.Business.Contracts;
 using FaceAnalyzer.Api.Business.Queries;
 using FaceAnalyzer.Api.Data.Entities;
+using FaceAnalyzer.Api.Service.Contracts;
+using FaceAnalyzer.Api.Service.Examples;
 using FaceAnalyzer.Api.Shared.Enum;
+using FaceAnalyzer.Api.Shared.Exceptions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-
-
+using Swashbuckle.AspNetCore.Filters;
+using SwaggerExample = Swashbuckle.AspNetCore.Filters.SwaggerExample;
 
 
 namespace FaceAnalyzer.Api.Service.Controllers;
 
 [ApiController]
 [Route("reactions")]
-
 public class ReactionController : ControllerBase
 {
     private readonly ISender _mediator;
-    
+
     public ReactionController(ISender mediator)
-    {;
+    {
+        ;
         _mediator = mediator;
     }
-    
+
     [HttpGet]
     public async Task<ActionResult<List<ReactionDto>>> Get()
     {
         var result = await _mediator.Send(new GetReactionsQuery(null));
+        return Ok(result);
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<ActionResult<ReactionDto>> Get(int id)
+    {
+        var queryResult = await _mediator.Send(new GetReactionsQuery(id));
+        var result = queryResult.Items.FirstOrDefault();
+        if (result is null)
+        {
+            throw new EntityNotFoundException("Reaction", id);
+        }
+
         return Ok(result);
     }
 
@@ -45,25 +61,35 @@ public class ReactionController : ControllerBase
     {
         var query = new GetReactionEmotionsQuery(id, null);
         var result = await _mediator.Send(query);
-        
+
         // Convert list to a csv file
         var stream = new MemoryStream();
         await using (var writeFile = new StreamWriter(stream, leaveOpen: true))
-        await using(var csv = new CsvWriter(writeFile, CultureInfo.InvariantCulture))
+        await using (var csv = new CsvWriter(writeFile, CultureInfo.InvariantCulture))
         {
             await csv.WriteRecordsAsync(result.Items);
         }
+
         stream.Position = 0;
-        return new FileStreamResult(stream, "text/csv"){ FileDownloadName = $"{nameof(Reaction)}#{id}.csv"};
+        return new FileStreamResult(stream, "text/csv") { FileDownloadName = $"{nameof(Reaction)}#{id}.csv" };
     }
-    
+
     [HttpPost]
-    public async Task<ActionResult<ReactionDto>> Create([FromBody] CreateReactionCommand dto)
+    [SwaggerRequestExample(typeof(CreateReactionDto), typeof(CreateReactionDtoExample))]
+    public async Task<ActionResult<ReactionDto>> Create([FromBody] CreateReactionDto dto)
     {
-        var result = await _mediator.Send(dto);
-        return Created($"/reactions/{result.Id}", result);
+        var command = new CreateReactionCommand(
+            StimuliId: dto.StimuliId,
+            ParticipantName: dto.ParticipantName,
+            EmotionReadings: dto.EmotionReadings
+        );
+        var result = await _mediator.Send(command);
+        return CreatedAtAction(nameof(Get), new
+        {
+            id = result.Id
+        }, result);
     }
-    
+
     [HttpDelete("{id}")]
     public async Task<ActionResult<ReactionDto>> Delete(int id)
     {
@@ -71,10 +97,4 @@ public class ReactionController : ControllerBase
         await _mediator.Send(command);
         return NoContent();
     }
-    
-    
-    
-    
-    
-    
 }

--- a/FaceAnalyzer.Api/Service/Examples/CreateReactionDtoExample.cs
+++ b/FaceAnalyzer.Api/Service/Examples/CreateReactionDtoExample.cs
@@ -1,0 +1,39 @@
+﻿using FaceAnalyzer.Api.Business.Contracts;
+using FaceAnalyzer.Api.Service.Contracts;
+using FaceAnalyzer.Api.Shared.Enum;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace FaceAnalyzer.Api.Service.Examples;
+
+public class CreateReactionDtoExample : IExamplesProvider<CreateReactionDto>
+{
+    public CreateReactionDto GetExamples()
+    {
+        var values = new Dictionary<EmotionType, double>();
+        values.Add(EmotionType.Anger, .29323);
+        values.Add(EmotionType.Disgust, .0323);
+        values.Add(EmotionType.Fear, .009323);
+        values.Add(EmotionType.Happiness, .29323);
+        values.Add(EmotionType.Sadness, .0001);
+        values.Add(EmotionType.Neutral, .00923);
+        values.Add(EmotionType.Surprise, .100923);
+        var readings = new EmotionReading(
+            DateTime.UtcNow.Millisecond,
+            values
+        );
+
+        return new CreateReactionDto(
+            2,
+            ParticipantName: "Algorithmy",
+            EmotionReadings: new List<EmotionReading>
+            {
+                readings,
+                readings,
+                readings,
+                readings,
+                readings,
+                readings
+            }
+        );
+    }
+}

--- a/FaceAnalyzer.Api/Service/IServiceCollectionExtensions.cs
+++ b/FaceAnalyzer.Api/Service/IServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
-﻿using System.Text;
+﻿using System.Reflection;
+using System.Text;
 using FaceAnalyzer.Api.Service.Middlewares;
 using FaceAnalyzer.Api.Shared;
 using FaceAnalyzer.Api.Shared.Security;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Filters;
 
 namespace FaceAnalyzer.Api.Service;
 
@@ -64,5 +66,38 @@ public static class IServiceCollectionExtensions
      
  
         } );
+    }
+
+    public static void ConfigureSwagger(this IServiceCollection services)
+    {
+        
+        services.AddSwaggerGen(c =>
+        {
+            c.SwaggerDoc("v1", new OpenApiInfo { Title = "Face Analyzer", Version = "v1" });
+    
+            c.ExampleFilters();
+
+            // c.OperationFilter<AddResponseHeadersFilter>(); // [SwaggerResponseHeader]
+
+            // var filePath = Path.Combine(AppContext.BaseDirectory, "WebApi.xml");
+            // c.IncludeXmlComments(filePath); // standard Swashbuckle functionality, this needs to be before c.OperationFilter<AppendAuthorizeToSummaryOperationFilter>()
+
+            // c.OperationFilter<AppendAuthorizeToSummaryOperationFilter>(); // Adds "(Auth)" to the summary so that you can see which endpoints have Authorization
+            // or use the generic method, e.g. c.OperationFilter<AppendAuthorizeToSummaryOperationFilter<MyCustomAttribute>>();
+
+            // add Security information to each operation for OAuth2
+            // c.OperationFilter<SecurityRequirementsOperationFilter>();
+            // or use the generic method, e.g. c.OperationFilter<SecurityRequirementsOperationFilter<MyCustomAttribute>>();
+
+            // // if you're using the SecurityRequirementsOperationFilter, you also need to tell Swashbuckle you're using OAuth2
+            // c.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
+            // {
+            //     Description = "Standard Authorization header using the Bearer scheme. Example: \"bearer {token}\"",
+            //     In = ParameterLocation.Header,
+            //     Name = "Authorization",
+            //     Type = SecuritySchemeType.ApiKey
+            // });
+        });
+        services.AddSwaggerExamplesFromAssemblies(Assembly.GetEntryAssembly());
     }
 }


### PR DESCRIPTION
- Added an endpoint to create emotions together with reaction in one request. 
- updated CreateReactionDto and add the list of EmotionReadings every **EmotionReading** object contains the time offset and dictionary of EmotionType => value 
here is an example for **EmotionReading** 
```json
{
      "time": 388,
      "values": {
        "Anger": 0.29323,
        "Disgust": 0.0323,
        "Fear": 0.009323,
        "Happiness": 0.29323,
        "Sadness": 0.0001,
        "Neutral": 0.00923,
        "Surprise": 0.100923
}
```

- Also Added Example for Swagger request.   